### PR TITLE
Installer URL fix

### DIFF
--- a/files/etc/profile.d/rvm.sh
+++ b/files/etc/profile.d/rvm.sh
@@ -5,12 +5,12 @@
 #
 if [ -n "${BASH_VERSION:-}" -o -n "${ZSH_VERSION:-}" ] ; then
 
+  : rvm_stored_umask:${rvm_stored_umask:=$(umask)}
   # Load user rvmrc configurations, if exist
   for file in /etc/rvmrc "$HOME/.rvmrc" ; do
     [[ -s "$file" ]] && source $file
   done
 
-  : rvm_stored_umask:${rvm_stored_umask:=$(umask)}
   # Load RVM if it is installed, try user then root install.
   if [[ -s "$rvm_path/scripts/rvm" ]] ; then
     source "$rvm_path/scripts/rvm"
@@ -48,7 +48,7 @@ if [ -n "${BASH_VERSION:-}" -o -n "${ZSH_VERSION:-}" ] ; then
   if [[ "${rvm_bin_path}" != "${rvm_path}/bin" ]] ; then
     regex="^([^:]*:)*${rvm_bin_path}(:[^:]*)*$"
     if [[ ! "${PATH}" =~ $regex ]] ; then
-	  __rvm_add_to_path prepend "${rvm_bin_path}"
+      __rvm_add_to_path prepend "${rvm_bin_path}"
     fi
   fi
 fi

--- a/manifests/packages/common.pp
+++ b/manifests/packages/common.pp
@@ -4,7 +4,7 @@ class rvm::packages::common {
   }
   
   exec { 'download-rvm-install':
-    command => 'wget -O /tmp/rvm https://rvm.beginrescueend.com/install/rvm',
+    command => 'wget -O /tmp/rvm https://raw.github.com/wayneeseguin/rvm/master/binscripts/rvm-installer',
     creates => '/tmp/rvm',
     unless  => 'which rvm',
   }


### PR DESCRIPTION
first commit is a bug fix, rvm upstream is not providing the installer script on beginrescueend.com, just at github.com URL

second one is just leave rvm.sh more compliant with upstream to not file bucket the original file as the content are the same (just whitespace and places were differing)
