### PR TITLE
Use correct packages for recent Ubuntu LTS releases

### DIFF
--- a/manifests/packages/ubuntu.pp
+++ b/manifests/packages/ubuntu.pp
@@ -1,8 +1,14 @@
 class rvm::packages::ubuntu {
-  $package_list = ['build-essential', 'bash', 'gawk', 'sed', 'grep',
-                   'gzip', 'bzip2', 'zlib1g-dev', 'libssl-dev', 
-                   'libreadline-gplv2-dev']
-                   
+
+  $package_list = $lsbdistcodename ? {
+    'hardy', 'intrepid', 'jaunty', 'karmic', 'lucid' => ['build-essential',
+                'bash', 'gawk', 'sed', 'grep', 'gzip', 'bzip2',
+                'zlib1g-dev', 'libssl-dev', 'libreadline-dev'],
+    default => ['build-essential', 'bash', 'gawk', 'sed', 'grep',
+                'gzip', 'bzip2', 'zlib1g-dev', 'libssl-dev',
+                'libreadline-gplv2-dev']
+  }
+
   # Virtualize Package list to prevent conflicts
   @package { $package_list:
     ensure => 'present',

--- a/manifests/packages/ubuntu.pp
+++ b/manifests/packages/ubuntu.pp
@@ -1,7 +1,7 @@
 class rvm::packages::ubuntu {
 
   $package_list = $lsbdistcodename ? {
-    'hardy', 'intrepid', 'jaunty', 'karmic', 'lucid' => ['build-essential',
+    /hardy|intrepid|jaunty|karmic|lucid/ => ['build-essential',
                 'bash', 'gawk', 'sed', 'grep', 'gzip', 'bzip2',
                 'zlib1g-dev', 'libssl-dev', 'libreadline-dev'],
     default => ['build-essential', 'bash', 'gawk', 'sed', 'grep',


### PR DESCRIPTION
I've got a little correction for the Ubuntu support in 7c22d654ead27d77be61dc2fd5242d4e9beb010d: 

The referenced readline package was split up in [current Ubuntu releases](http://packages.ubuntu.com/search?keywords=libreadline-gplv2-dev), so to get backwards compatibility I've added a switch for older Ubuntu releases.

_tested with Ubuntu 10.04.3 LTS_
