### PR TITLE
rvm wrapper support

### DIFF
--- a/manifests/define/wrapper.pp
+++ b/manifests/define/wrapper.pp
@@ -1,0 +1,25 @@
+define rvm::define::wrapper(
+  $ensure = 'present',
+  $ruby_version,
+  $prefix
+) {
+  Exec {
+    path    => '/usr/local/rvm/bin:/bin:/sbin:/usr/bin:/usr/sbin',
+  }
+  $rvm_source = "source /usr/local/rvm/scripts/rvm"
+  $wrapper_exists = "bash -c '${rvm_source} ; rvm use ${ruby_version} ; which ${prefix}_${name}'"
+
+  if $ensure == 'present' {
+    exec { "rvm-alias-create-${name}-${ruby_version}":
+      command => "bash -c '${rvm_source} ; rvm use ${ruby_version} ; rvm wrapper ${ruby_version} ${prefix} ${name}'",
+      unless => $wrapper_exists,
+      require => [Class['rvm'], Exec["install-ruby-${ruby_version}"]],
+    }
+  } elsif $ensure == 'absent' {
+    exec { "rvm-gemset-delete-${name}-${ruby_version}":
+      command => "bash -c '${rvm_source} ; rvm use ${ruby_version} ; rm `which ${prefix}_${name}`'",
+      onlyif => $wrapper_exists,
+      require => [Class['rvm'], Exec["install-ruby-${ruby_version}"]],
+    }
+  }
+}


### PR DESCRIPTION
And another one. I added rvm wrapper support, inspired by puppet-rvm gemsets. :-)

e.g.

``` ruby
  rvm::define::wrapper { ['god', 'thin']:
    ensure       => 'present',
    prefix       => 'bootup',
    ruby_version => 'ruby-1.9.3',
  }
```

will create wrappers for thin and god, like

```
lrwxrwxrwx 1 root rvm 43 22. Mai 12:47 /usr/local/rvm/bin/bootup_god -> /usr/local/rvm/wrappers/ruby-1.9.3-p194/god
```
