### PR TITLE
Moves from removed 'rvm gem' command to 'gem'

### DIFF
--- a/manifests/define/gem.pp
+++ b/manifests/define/gem.pp
@@ -26,13 +26,13 @@ define rvm::define::gem(
     $gem = {
       'install'   => "rvm ${rubyset_version} gem install ${name} --no-ri --no-rdoc",
       'uninstall' => "rvm ${rubyset_version} gem uninstall ${name}",
-      'lookup'    => "rvm gem list | grep ${name}",
+      'lookup'    => "gem list | grep ${name}",
     }
   } else {
     $gem = {
       'install'   => "rvm ${rubyset_version} gem install ${name} -v ${gem_version} --no-ri --no-rdoc",
       'uninstall' => "rvm ${rubyset_version} gem uninstall ${name} -v ${gem_version}",
-      'lookup'    => "rvm gem list | grep ${name} | grep ${gem_version}",
+      'lookup'    => "gem list | grep ${name} | grep ${gem_version}",
     }
   }
 

--- a/manifests/define/gem.pp
+++ b/manifests/define/gem.pp
@@ -16,23 +16,24 @@ define rvm::define::gem(
   $rvm_ruby = "${rvm_path}/rubies"
   
   if $gemset == '' {
-    $rvm_depency = "install-ruby-${ruby_version}"        
+    $rvm_depency = "install-ruby-${ruby_version}"
+    $rubyset_version = $ruby_version
   } else {
-    $rvm_depency = "rvm-gemset-create-${gemset}-${ruby_version}"        
+    $rvm_depency = "rvm-gemset-create-${gemset}-${ruby_version}"
     $rubyset_version = "${ruby_version}@${gemset}"
   }
   # Setup proper install/uninstall commands based on gem version.
   if $gem_version == '' {
     $gem = {
-      'install'   => "rvm ${rubyset_version} gem install ${name} --no-ri --no-rdoc",
-      'uninstall' => "rvm ${rubyset_version} gem uninstall ${name}",
-      'lookup'    => "gem list | grep ${name}",
+      'install'   => "rvm ${rubyset_version} do gem install ${name} --no-ri --no-rdoc",
+      'uninstall' => "rvm ${rubyset_version} do gem uninstall ${name}",
+      'lookup'    => "rvm ${rubyset_version} do gem list | grep ${name}",
     }
   } else {
     $gem = {
-      'install'   => "rvm ${rubyset_version} gem install ${name} -v ${gem_version} --no-ri --no-rdoc",
-      'uninstall' => "rvm ${rubyset_version} gem uninstall ${name} -v ${gem_version}",
-      'lookup'    => "gem list | grep ${name} | grep ${gem_version}",
+      'install'   => "rvm ${rubyset_version} do gem install ${name} -v ${gem_version} --no-ri --no-rdoc",
+      'uninstall' => "rvm ${rubyset_version} do gem uninstall ${name} -v ${gem_version}",
+      'lookup'    => "rvm ${rubyset_version} do gem list | grep ${name} | grep ${gem_version}",
     }
   }
 

--- a/manifests/packages/ubuntu.pp
+++ b/manifests/packages/ubuntu.pp
@@ -3,10 +3,10 @@ class rvm::packages::ubuntu {
   $package_list = $lsbdistcodename ? {
     /hardy|intrepid|jaunty|karmic|lucid/ => ['build-essential',
                 'bash', 'gawk', 'sed', 'grep', 'gzip', 'bzip2',
-                'zlib1g-dev', 'libssl-dev', 'libreadline-dev'],
+                'zlib1g-dev', 'libssl-dev', 'libreadline-dev', 'curl'],
     default => ['build-essential', 'bash', 'gawk', 'sed', 'grep',
                 'gzip', 'bzip2', 'zlib1g-dev', 'libssl-dev',
-                'libreadline-gplv2-dev']
+                'libreadline-gplv2-dev', 'curl']
   }
 
   # Virtualize Package list to prevent conflicts


### PR DESCRIPTION
the following error currently occurs when trying to use `rvm::define::gem`

```
Notice: /Stage[main]/Gb::Ruby/Rvm::Define::Gem[bundler]/Exec[rvm-gem-install-bundler-ruby-2.0.0-p247]/returns:
Please note that `rvm gem ...` was removed,
try `gem install bundler --no-ri --no-rdoc` or `rvm all do gem install bundler --no-ri --no-rdoc` instead. ( see: 'rvm usage' )
```

switching from `rvm gem` to `gem` fixes the problem

EDIT: added a new commit, which adds curl as a dependency for Ubuntu. not related at all, but was necessary for my project. if desired, i can move this into two separate pull requests
